### PR TITLE
US 4: Merchant Coupon Deactivate

### DIFF
--- a/app/controllers/coupons_controller.rb
+++ b/app/controllers/coupons_controller.rb
@@ -26,6 +26,17 @@ class CouponsController < ApplicationController
     @coupon = @merchant.coupons.find(params[:id])
   end
 
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @coupon = @merchant.coupons.find(params[:id])
+
+    if @coupon.update_status
+      redirect_to merchant_coupon_path(@merchant, @coupon)
+    else
+      redirect_to merchant_coupon_path(@merchant, @coupon)
+    end
+  end
+
   private
 
   def coupon_params

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -10,7 +10,7 @@ class Coupon < ApplicationRecord
   validate :coupon_limit_validation, on: :create
 
   enum discount_type: { percent_off: "Percent Off", dollar_off: "Dollars Off"}
-  enum status: { Active: 0, Inactive: 1 }
+  enum status: { active: 0, inactive: 1 }
 
   #https://api.rubyonrails.org/v7.1.2/classes/ActiveModel/Errors.html
 
@@ -23,4 +23,24 @@ class Coupon < ApplicationRecord
   def usage_count
     transactions.count
   end
+
+  def update_status
+    if active? && cannot_deactivate_due_to_pending_invoice?
+      return false
+    else
+      if active?
+        self.status = :inactive
+      else
+        self.status = :active
+      end
+      save
+    end
+  end
+
+  private
+
+  def cannot_deactivate_due_to_pending_invoice?
+    invoices.in_progress.exists?
+  end
+
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -6,14 +6,4 @@ class Transaction < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :coupon, optional: true
-
-  def process_transaction(params)
-      
-    if params[:coupon_code]
-      coupon = Coupon.find_by(code: params[:coupon_code])
-      transaction.coupon = coupon if coupon.present? && coupon.active?
-    end
-  
-    transaction.save
-  end
 end

--- a/app/views/coupons/show.html.erb
+++ b/app/views/coupons/show.html.erb
@@ -1,5 +1,11 @@
 <%= render partial: "shared/nav" %>
 
+<% if @coupon.active? %>
+  <%= button_to 'Deactivate Coupon', [@merchant, @coupon], method: :patch, action: :update %>
+<% else %>
+  <%= button_to 'Activate Coupon', [@merchant, @coupon], method: :patch, action: :update %>
+<% end %>
+
 <p>Name: <%= @coupon.name %></p>
 <p>Code: <%= @coupon.code %></p>
 <p>Discount: <%= @coupon.discount_value %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :coupons, only: [:index, :new, :create, :show]
+    resources :coupons, only: [:index, :new, :create, :show, :update]
   end
 
   namespace :admin do

--- a/spec/features/coupons/show_spec.rb
+++ b/spec/features/coupons/show_spec.rb
@@ -6,13 +6,27 @@ RSpec.describe Coupon do
     end
 
     it "shows correct coupon information" do
-
       visit merchant_coupon_path(@merchant, @coupon1)
   
       expect(page).to have_content(@coupon1.name)
       expect(page).to have_content(@coupon1.code)
       expect(page).to have_content("Discount: 10")
-      expect(page).to have_content("Status: Active")
+      expect(page).to have_content("Status: active")
+    end
+
+    it "allows merchants to toggle coupon status" do
+      visit merchant_coupon_path(@merchant, @coupon1)
+
+      expect(page).to have_content(@coupon1.name)
+      expect(page).to have_content(@coupon1.code)
+      expect(page).to have_content("Discount: 10")
+      expect(page).to have_content("Status: active")
+
+      expect(page).to have_content("Deactivate Coupon")
+      click_button "Deactivate Coupon"
+      
+      visit current_path
+      expect(page).to have_content("Status: inactive")
     end
   end
 end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -20,4 +20,25 @@ RSpec.describe Coupon, type: :model do
       expect(new_coupon.errors[:base]).to include("Coupon limit reached. You can have a maximum of 5 coupons at a time.")
     end
   end
+
+  describe "update coupon status" do
+    it "toggles the status from active to inactive" do
+      @merchant = Merchant.create!(name: "J-Mart")
+      @coupon = Coupon.create!(name: "10OFF", code: "CODE10", discount_value: 10, discount_type: "Percent Off", merchant: @merchant)
+
+      expect(@coupon.active?).to be true
+      @coupon.update_status
+      expect(@coupon.inactive?).to be true
+    end
+
+    it "toggles the status from inactive to active" do
+      @merchant = Merchant.create!(name: "J-Mart")
+      @coupon = Coupon.create!(name: "10OFF", code: "CODE10", discount_value: 10, discount_type: "Percent Off", merchant: @merchant, status: "inactive")
+
+      expect(@coupon.inactive?).to be true
+      @coupon.update_status
+      expect(@coupon.active?).to be true
+    end
+
+  end
 end


### PR DESCRIPTION
As a merchant
When I visit one of my active coupon's show pages
I see a button to deactivate that coupon
When I click that button
I'm taken back to the coupon show page
And I can see that its status is now listed as 'inactive'.

Sad Paths to consider:
A coupon cannot be deactivated if there are any pending invoices with that coupon.