### PR TITLE
Us 8 Admin Invoice Show Page: Subtotal and Grand Total Revenues

### DIFF
--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -44,4 +44,14 @@
     </tbody>
   </table>
 
+  <p>Subtotal: <%= @invoice.total_revenue %></p>
+  <p>Grand Total: <%= @invoice.grand_total %></p>
+
+<% if @invoice.coupon %>
+  <p>
+    Coupon Applied: <%= @invoice.coupon.name %>
+    (Code: <%= @invoice.coupon.code %>)
+  </p>
+<% end %>
+
 </body>

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
-  describe "grand total" do
+  describe "#grand_total" do
     it "equals the total revenue when no coupon is applied" do
 
       expect(@invoice_1.grand_total).to eq(100)
@@ -55,6 +55,69 @@ RSpec.describe Invoice, type: :model do
       @invoice_1.update(coupon: @coupon)
 
       expect(@invoice_1.grand_total).to eq(0)
+    end
+  end
+  
+  describe "#applied_discount" do
+    before :each do
+      @merchant1 = Merchant.create!(name: "Hair Care")
+
+      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 100, merchant_id: @merchant1.id)
+      
+      @customer_1 = Customer.create!(first_name: "Joey", last_name: "Smith")
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 1, unit_price: @item_1.unit_price, status: 2)
+
+      @coupon_percent = Coupon.create!(name: "10 Percent Off", code: "10FF", discount_value: 10, discount_type: "percent_off", merchant_id: @merchant1.id)
+      @coupon_dollar = Coupon.create!(name: "20 Percent Off", code: "20FF", discount_value: 20, discount_type: "dollar_off", merchant_id: @merchant1.id)
+      @invoice_1.update(coupon: @coupon)
+    end
+
+    it "returns 0 if no coupon is applied" do
+      expected_discount = @invoice_1.send(:applied_discount)
+      expect(expected_discount).to eq(0)
+    end
+  
+    it "applies percent off discount correctly" do
+      @invoice_1.update(coupon: @coupon_percent)
+      
+      expect(@invoice_1.send(:applied_discount)).to eq(@invoice_1.send(:calculate_percentage_discount))    
+    end
+  
+    it "applies dollar off discount correctly" do
+      @invoice_1.update(coupon: @coupon_dollar)
+      
+      expect(@invoice_1.send(:applied_discount)).to eq(@invoice_1.send(:calculate_fixed_discount))
+    end
+  end
+
+  describe "invoice total sad paths" do
+    before :each do
+      @merchant1 = Merchant.create!(name: "Hair Care")
+      @merchant2 = Merchant.create!(name: "Jewelry")
+
+      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 100, merchant_id: @merchant1.id)
+      @item_2 = Item.create!(name: "Conditioner", description: "This makes your hair shiny", unit_price: 200, merchant_id: @merchant2.id,)
+      
+      @customer_1 = Customer.create!(first_name: "Joey", last_name: "Smith")
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 2, unit_price: @item_1.unit_price, status: 2)
+      @ii_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 1, unit_price: @item_2.unit_price, status: 2)
+
+      @coupon = Coupon.create!(name: "10 Percent Off", code: "10FF", discount_value: 10, discount_type: "percent_off", merchant_id: @merchant1.id)
+      @invoice_1.update(coupon: @coupon)
+    end
+
+    it "applies coupon discount only to items from the same merchant" do
+      expected_subtotal = 400 
+      expected_discount = 20 
+      expected_grand_total = expected_subtotal - expected_discount
+  
+      expect(@invoice_1.total_revenue).to eq(expected_subtotal)
+      expect(@invoice_1.discount_amount).to eq(expected_discount)
+      expect(@invoice_1.grand_total).to eq(expected_grand_total)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,12 @@
 require "simplecov"
-SimpleCov.start
+SimpleCov.start 'rails' do
+  add_filter '/bin/'
+  add_filter '/db/'
+  add_filter '/spec/'
+
+  add_group 'Models', 'app/models'
+  add_group 'Controllers', 'app/controllers'
+end
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
As an admin
When I visit one of my admin invoice show pages
I see the name and code of the coupon that was used (if there was a coupon applied)
And I see both the subtotal revenue from that invoice (before coupon) and the grand total revenue (after coupon) for this invoice.

Alternate Paths to consider:
There may be invoices with items from more than 1 merchant. Coupons for a merchant only apply to items from that merchant.
When a coupon with a dollar-off value is used with an invoice with multiple merchants' items, the dollar-off amount applies to the total amount even though there may be items present from another merchant.